### PR TITLE
Remove portal from tinkerbell triage party

### DIFF
--- a/configmap-tinkerbell.yaml
+++ b/configmap-tinkerbell.yaml
@@ -17,7 +17,6 @@ data:
         - https://github.com/tinkerbell/pbnj
         - https://github.com/tinkerbell/tink
         - https://github.com/tinkerbell/proposals
-        - https://github.com/tinkerbell/portal
         - https://github.com/tinkerbell/tinkerbell.org
     collections:
       - id: daily


### PR DESCRIPTION
Portal has moved out of the Tinkerbell project over to https://github.com/kubnix/tinkerbell-dashboard