### PR TITLE
Refactor rules based on new Tinkerbell labels, add lint-install repo

### DIFF
--- a/configmap-tinkerbell.yaml
+++ b/configmap-tinkerbell.yaml
@@ -20,6 +20,7 @@ data:
         - https://github.com/tinkerbell/hub
         - https://github.com/tinkerbell/infrastructure
         - https://github.com/tinkerbell/k8s-sandbox
+        - https://github.com/tinkerbell/lint-install
         - https://github.com/tinkerbell/osie
         - https://github.com/tinkerbell/pbnj
         - https://github.com/tinkerbell/proposals
@@ -28,89 +29,94 @@ data:
         - https://github.com/tinkerbell/tink
         - https://github.com/tinkerbell/tinkerbell-docs
         - https://github.com/tinkerbell/tinkerbell.org
+
     collections:
-      - id: daily
-        name: Daily Triage
-        dedup: false
-        description: To be emptied out daily
+      - id: weekly
+        name: Semi-weekly
+        dedup: true
+        description: >
+          Reviewed during the week.
+
+          * Keeping an open dialog with our users
+          * Initial prioritization (does not have to be perfect)
         rules:
-          - issue-needs-comment
-          - p1-fix-overdue
-          - p1-followup-overdue
           # Don't leave code reviews hanging
+          - pr-approved-stale
           - pr-reviewable
+          # Expectation violations
+          - issue-needs-priority-too-long
+          - issue-needs-comment-too-long
+          - issue-important-too-long
           # missing initial feedback
           - issue-needs-kind
+          - issue-needs-priority
+          - issue-needs-comment
           # reprioritize
           - issue-new-with-reactions
           - issue-new-with-many-commenters
           # Don't forget our users
-          - issue-has-question
-          - issue-updated-kind-question
+          - issue-updated-needs-info
+          - issue-updated-has-question
 
-      - id: weekly
-        name: Weekly Triage
+      - id: biweekly
+        name: Bi-weekly
         dedup: true
-        description: To be emptied out weekly
+        description: >
+          Once every two weeks, we meet up to address loose ends. Prioritize:
+
+          * Keeping an open dialog with our users
+          * Raising the priority for hot issues
         rules:
           - discuss
+          # Issues needing closure
+          - issue-stale-needs-info
+          - issue-stale-support
+          # People with questions
+          - issue-has-question
+          - issue-updated-support
+          # Expectations
+          - issue-near-important-too-long
+          - issue-near-longterm-too-long
+          # PR's needing closure
+          - pr-reviewable-older
+          - pr-approved-stale
+          - pr-unapproved-stale
           # Issues needing reprioritization
           - many-reactions
           - many-commenters
-          # Issues needing reprioritization
           - issue-zombies
-          # PR's needing closure
-          - pr-approved-stale
-          - pr-unapproved-stale
-          - birthday
 
-      - id: quarterly
-        name: Quarterly Scrub
+      - id: scrub
+        name: Quarterly
         dedup: true
+        description: >
+          Once every quarter, we look for stale issues and de-duplicate. Prioritize:
+
+          * De-duplication
+          * Keeping the bug queue relevant
+          * Making tough decisions about long-standing requests
         rules:
-          - question-old
+          - features-recv
+          - features-old
+          - bugs-recv
           - bugs-old
-          - enhancement-old
+          - other-recv
           - other-old
 
-      - id: recv
-        name: "Receive queue"
+      - id: important
+        name: Important
         description: >
-          Issues that may be waiting for our response
-      
-          NOTE: for this to work properly, GitHub token must have read access to read organization members
+          Items labeled as priority/important-soon or priority/critical-urgent.
+        overflow: 3
+        dedup: true
         rules:
-          - question-recv
-          - bugs-recv
-          - enhancement-recv
-          - other-recv
-
-      - id: p1
-        name: P1
-        description: All hands on deck!
-        rules:
-          - p1-prs
-          - p1-enhancements
-          - p1-bugs
-          - p1-other
-
-      - id: p2
-        name: P2
-        description: To be resolved within 6 weeks
-        rules:
-          - p2-prs
-          - p2-enhancements
-          - p2-bugs
-          - p2-other
-
-      - id: p3
-        name: P3
-        description: To be resolved within 12 weeks
-        rules:
-          - p3-prs
-          - p3-enhancements
-          - p3-bugs
-          - p3-other
+          - important-not-milestoned
+          - important-milestoned
+          - important-assignee-updated
+          - important-pr-needs-review
+          - important-pr-needs-work
+          - important-pr-needs-merge
+          - important-recently-closed
 
       - id: similar
         name: Similar
@@ -119,7 +125,7 @@ data:
           - similar-prs
           - similar-issues
 
-      - id: open
+      - id: __open__
         name: All open PR's and Issues that should be considered for repository stats (hidden)
         used_for_statistics: true
         hidden: true
@@ -127,16 +133,142 @@ data:
           - open-prs
           - open-issues
 
+      - id: __velocity__
+        name: issues to include in velocity metrics
+        used_for_statistics: true
+        hidden: true
+        rules:
+          - closed-milestone-issues
+
     rules:
-      ### Daily Triage ####
-      issue-needs-comment:
-        name: "Unresponded, older than 7 days"
-        resolution: "Respond to the issue"
+      ### Milestone Kanban ###
+      milestone-not-started:
+        name: "Not started"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - tag: "!assignee-updated"
+          - tag: "!(assignee-open-pr|assignee-closed-pr)"
+      milestone-assignee-updated:
+        name: "In Progress"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - tag: "assignee-updated"
+          - tag: "!(pr-changes-requested|pr-reviewer-comment|pr-unreviewed|pr-new-commits|pr-approved|pr-changes-requested)"
+      milestone-pr-needs-work:
+        name: "PR needs work"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - tag: "(pr-changes-requested|pr-reviewer-comment)"
+      milestone-pr-needs-review:
+        name: "PR needs Review"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - tag: "(pr-unreviewed|pr-new-commits)"
+      milestone-pr-needs-merge:
+        name: "PR needs Merge"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - tag: "(pr-approved|pr-approved-but-pushed)"
+      milestone-recently-closed:
+        name: "Finish Line"
+        type: issue
+        filters:
+          - tag: open-milestone
+          - state: closed
+          - updated: -30d
+
+      ### Important Kanban ###
+      important-not-milestoned:
+        name: "Not in milestone"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: "!open-milestone"
+          - tag: "!assignee-updated"
+          - tag: "!(assignee-open-pr|assignee-closed-pr)"
+      important-milestoned:
+        name: "In Milestone"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: open-milestone
+          - tag: "assignee-updated"
+          - tag: "!(pr-changes-requested|pr-reviewer-comment|pr-unreviewed|pr-new-commits|pr-approved|pr-changes-requested)"
+      important-assignee-updated:
+        name: "In Progress"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: "assignee-updated"
+          - tag: "!(pr-changes-requested|pr-reviewer-comment|pr-unreviewed|pr-new-commits|pr-approved|pr-changes-requested)"
+      important-pr-needs-work:
+        name: "PR needs work"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: "(pr-changes-requested|pr-reviewer-comment)"
+      important-pr-needs-review:
+        name: "PR needs Review"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: "(pr-unreviewed|pr-new-commits)"
+      important-pr-needs-merge:
+        name: "PR needs Merge"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - tag: "(pr-approved|pr-approved-but-pushed)"
+      important-recently-closed:
+        name: "Recently closed"
+        type: issue
+        filters:
+          - label: "priority/important-soon|priority/critical-urgent"
+          - state: closed
+          - updated: -30d
+
+      ### Semi-Weekly Triage ####
+      # Expectation violations
+      issue-needs-priority-too-long:
+        name: "Unprioritized issues older than 7 days"
+        resolution: "Add a priority/ or kind/support label"
+        type: issue
+        filters:
+          - label: "!priority/.*"
+          - label: "!kind/support"
+          - label: "!kind/design"
+          - label: "!triage/discuss"
+          - created: +7d
+
+      issue-needs-comment-too-long:
+        name: "Uncommented older than 7 days"
+        resolution: "Add a comment"
         type: issue
         filters:
           - tag: "!commented"
           - tag: "recv"
-          - created: +1w
+          - created: +7d
+
+      issue-important-too-long:
+        name: "Important soon, but no updates in 60 days -- exceeds limit"
+        resolution: "Downgrade to important-longterm"
+        type: issue
+        filters:
+          - label: "priority/important-soon"
+          - updated: +60d
+
+      issue-longterm-too-long:
+        name: "Important longterm, but no updates in 120 days -- exceeds limit"
+        resolution: "Downgrade to backlog"
+        type: issue
+        filters:
+          - label: "priority/important-longterm"
+          - updated: +120d
 
       # Don't leave code reviews hanging
       pr-reviewable:
@@ -146,117 +278,146 @@ data:
         filters:
           - label: "!do-not-merge.*"
           - label: "!needs-rebase"
-          - label: "!.*wip"
           - label: "!cncf-cla: no"
           - tag: "!changes-requested"
           - tag: "!send"
-          - tag: "!commented"
-          
+          - tag: "!draft"
           # Temporarily workaround inability to track PR eligibility
           - updated: +1d
+
+      pr-reviewable-older:
+        name: "Pull Requests: Review Ready"
+        resolution: "Review requests or mark them as do-not-merge/work-in-progress"
+        type: pull_request
+        filters:
+          - label: "!do-not-merge.*"
+          - label: "!needs-rebase"
+          - label: "!cncf-cla: no"
+          - tag: "!changes-requested"
+          - tag: "!send"
+          - tag: "!draft"
+          - updated: +2d
 
       # Issues missing initial feedback
       issue-needs-kind:
         name: "Unkinded Issues"
-        resolution: "Add a label"
+        resolution: "Add a kind/ label"
         type: issue
         filters:
-          - label: "!.*(kind|bug|documentation|enhancement|question|todo|idea|epic).*"
+          - label: "!kind/.*"
+          - label: "!triage/discuss"
+
+      issue-needs-priority:
+        name: "Unprioritized Issues (newer)"
+        resolution: "Add a priority/ laber or mark issue as kind/support|kind/design"
+        type: issue
+        filters:
+          - label: "!priority/.*"
+          - label: "!kind/support"
+          - label: "!kind/design"
+          # avoid duplicating unkinded issues
+          - label: "triage|kind"
+          - created: -5d
+
+      issue-needs-comment:
+        name: "Uncommented Issues"
+        resolution: "Add a comment"
+        type: issue
+        filters:
+          - tag: "!commented"
+          - tag: "recv"
+          - created: -5d
 
       # Issues that may need reprioritized
       issue-new-with-reactions:
-        name: "New, has multiple reactions, but not P1"
-        resolution: "Check if issue should be prioritized as P1"
+        name: "New, has multiple reactions, but not important-soon"
+        resolution: "Check if issue should be prioritized as important-soon"
         type: issue
         filters:
           - reactions: ">2"
           - created: -10d
           - tag: "!send"
-          - label: "!P1"
+          - label: "!priority/important-soon"
 
       issue-new-with-many-commenters:
-        name: "New, has multiple commenters, but not p1"
-        resolution: "Check if issue should be prioritized as p1"
+        name: "New, has multiple commenters, but not important-soon"
+        resolution: "Check if issue should be prioritized as important-soon"
         type: issue
         filters:
           - commenters: ">3"
           - created: -10d
           - tag: "!send"
-          - label: "!P1"
+          - label: "!priority/important-soon"
 
-      # People with questions
-      issue-updated-kind-question:
-        name: "question label issue not responded to for over a week"
-        resolution: "Remove question label, or add a comment"
+      # Don't forget our users
+      issue-updated-needs-info:
+        name: "needs information, has update"
+        resolution: "Comment and remove triage/needs-information tag"
         type: issue
         filters:
+          - label: triage/needs-information
           - tag: recv
-          - label: ".*question"
-          - tag: "!member-last"
-          - tag: "!contributor-last"
-          - responded: +8d
 
-      issue-has-question:
-        name: "Reporter asked a question over a week ago"
+      issue-updated-has-question:
+        name: "Recently updated issue has a question"
         resolution: "Add an answer"
         type: issue
         filters:
           - tag: recv-q
+          - label: "!triage/needs-information"
           - tag: "!member-last"
           - tag: "!contributor-last"
-          - responded: +7d
+          - responded: +3d
+          - updated: -7d
 
-      ####### Weekly Triage #########
+      ####### Bi-Weekly Triage #########
       discuss:
         name: "Items for discussion"
         resolution: "Discuss and remove label"
         filters:
-          - label: ".*discuss"
+          - label: triage/discuss
           - state: "all"
 
-      # SLO nearing
-      p1-followup-overdue:
-        name: "p1 issue, no comments in 3 days"
-        resolution: "Downgrade to p2"
+      # Nearing expectation limits
+      issue-near-important-too-long:
+        name: "Important soon, but no updates in 40 days -- nearing limit"
+        resolution: "Downgrade to important-longterm"
         type: issue
         filters:
-          - label: "P1"
-          - tag: recv
-          - responded: +3d
+          - label: "priority/important-soon|priority/critical-urgent"
+          - updated: +40d
 
-      p1-fix-overdue:
-        name: "p1 bug, older than 7 days"
-        resolution: "Downgrade to p2"
+      issue-near-longterm-too-long:
+        name: "Important longterm, but no updates in 110 days -- nearing limit"
+        resolution: "Downgrade to backlog"
         type: issue
         filters:
-          - label: "P1"
-          - created: +7d
+          - label: "priority/important-longterm"
+          - updated: +110d
 
       # issues needing reprioritization
       many-reactions:
-        name: "many reactions, low priority, no recent comment"
-        resolution: "Bump the priority, add a comment"
+        name: "many reactions, low priority"
+        resolution: "Upgrade to priority-soon, priority-longterm, or longterm-support"
         filters:
           - reactions: ">3"
-          - reactions-per-month: ">1"
-          - label: "!P1"
-          - label: "!P2"
-          - label: "!P3"
-          - responded: +60d
+          - reactions-per-month: ">0.75"
+          - label: "!priority/important-soon"
+          - label: "!priority/important-longterm"
+          - label: "!long-term-support"
 
       many-commenters:
-        name: "many commenters, low priority, no recent comment"
-        resolution: "Consider increasing priority"
+        name: "many commenters, low priority"
+        resolution: "Upgrade to priority-soon, priority-longterm, or longterm-support"
         type: issue
         filters:
-          - commenters: ">3"
+          - commenters: ">2"
           - commenters-per-month: ">1.9"
           - created: "+30d"
-          - label: "!P1"
-          - label: "!P2"
-          - label: "!P3"
-          - tag: "!member-last"
-          - responded: "+60d"
+          - label: "!priority/important-soon"
+          - label: "!priority/important-longterm"
+          - label: "!long-term-support"
+          - responded: "+30d"
 
       issue-zombies:
         name: "Screaming into the void"
@@ -264,17 +425,33 @@ data:
         type: issue
         filters:
           - state: closed
+          - updated: -7d
+          - tag: recv
           - comments-while-closed: ">1"
-          - updated: "-14d"
-          - tag: "!member-last"
 
       # Issues needing closure
-      birthday:
-        name: "Forgotten Birthdays - over a year old, no response in 6 months"
-        resolution: "Close or comment on what it would take to address this issue"
+      issue-stale-needs-info:
+        name: "Needs information for over 2 weeks"
+        resolution: "Close or remove triage/needs-information label"
+        type: issue
         filters:
-          - created: +365d
-          - responded: +180d
+          - label: triage/needs-information
+          - updated: +13d
+
+      issue-stale-support:
+        name: "Support request over 30 days old"
+        resolution: "Close, or add to triage/long-term-support"
+        type: issue
+        filters:
+          - label: kind/support
+          - label: "!long-term-support"
+          - updated: +29d
+
+      ancient-issues:
+        name: "Ancient issues"
+        resolution: "Close or add comment that this issue should stick around"
+        filters:
+          - updated: +250d
 
       # PR's needing closure
       pr-approved-stale:
@@ -283,9 +460,8 @@ data:
         filters:
           - label: "!do-not-merge.*"
           - label: "!needs-rebase"
-          - label: "approved"
+          - tag: "approved"
           - updated: +5d
-          - responded: +2d
 
       pr-unapproved-stale:
         name: "Pull Requests: Stale"
@@ -294,72 +470,51 @@ data:
         filters:
           - created: +20d
           - updated: +5d
-          - responded: +2d
-      
+
+      # People with questions
+      issue-has-question:
+        name: "Overdue answers for a question"
+        resolution: "Add a comment"
+        type: issue
+        filters:
+          - tag: recv-q
+          - label: "!triage/needs-information"
+          - tag: "!member-last"
+          - tag: "!contributor-last"
+          - responded: +6d
+
+      issue-updated-support:
+        name: "Updated support requests"
+        resolution: "Move out of support, or add a comment"
+        type: issue
+        filters:
+          - tag: recv
+          - label: "!triage/needs-information"
+          - label: "triage/support"
+          - tag: "!member-last"
+          - tag: "!contributor-last"
+          - responded: +6d
+
       ## Bug Scrub ##
-      question-old:
-        name: "Questions that have been open for >3 weeks"
-        resolution: "Comment or close the issue"
-        type: issue
-        filters:
-          - responded: +7d
-          - created: +21d
-          - label: ".*question"
-
-      enhancement-old:
-        name: "Features that have been commented on within 90 days"
-        resolution: "Comment or close the issue"
-        type: issue
-        filters:
-          - responded: +1d
-          - created: +1d
-          - label: ".*(feature|enhancement|idea).*"
-
-      bugs-old:
-        name: "Bugs that have not been commented on within 90 days"
-        resolution: "Comment or close the issue"
-        type: issue
-        filters:
-          - label: ".*bug.*"
-          - responded: +1d
-          - created: +1d
-          - label: "!priority/awaiting-evidence"
-
-      other-old:
-        name: "Other items that have not been commented on within 90 days"
-        resolution: "Comment or close the issue"
-        type: issue
-        filters:
-          - responded: +1d
-          - created: +1d
-          - label: "!.*question"
-          - label: "!.*(feature|enhancement).*"
-          - label: "!.*bug"
-
-      # Receive queue
-      question-recv:
-        name: "Questions awaiting follow-up"
-        resolution: "Comment or close the issue"
-        type: issue
-        filters:
-          - tag: recv
-          - label: ".*question"
-
       bugs-recv:
-        name: "Bugs awaiting follow-up"
+        name: "Bugs that deserve a follow-up comment"
         resolution: "Comment or close the issue"
         type: issue
         filters:
           - tag: recv
-          - label: ".*bug"
+          - responded: +45d
+          - created: +45d
+          - label: "kind/bug"
 
-      enhancement-recv:
-        name: "Features awaiting follow-up"
+      features-recv:
+        name: "Features that deserve a follow-up comment"
         resolution: "Comment or close the issue"
         type: issue
         filters:
           - tag: recv
-          - label: ".*(feature|enhancement|idea).*"
+          - responded: +60d
+          - created: +30d
+          - label: "kind/feature"
 
       other-recv:
         name: "Items that deserve a follow-up comment"
@@ -368,107 +523,38 @@ data:
         filters:
           - tag: recv
           - responded: +30d
-          - label: "!.*(feature|enhancement).*"
-          - label: "!.*bug"
-          - label: ".*question"
-      
-      # P0
-      p1-bugs:
-        name: "p1 Bugs"
+          - label: "!kind/feature"
+          - label: "!kind/bug"
+          - label: "!kind/support"
+
+      features-old:
+        name: "Features that have not been commented on in 180 days"
+        resolution: "Comment or close the issue"
         type: issue
-        resolution: Close or deprioritize
         filters:
-          - label: "P1"
-          - label: "bug"
+          - responded: +180d
+          - created: +180d
+          - label: "kind/feature"
 
-      p1-enhancements:
-        name: "p1 Enhancements"
+      bugs-old:
+        name: "Bugs that have not been commented on within 180 days"
+        resolution: "Comment or close the issue"
         type: issue
-        resolution: Close or deprioritize
         filters:
-          - label: "P1"
-          - label: "enhancement"
+          - label: "kind/bug"
+          - responded: +180d
+          - created: +180d
 
-      p1-other:
-        name: "p1 Other"
+      other-old:
+        name: "Other items that have not been commented on within 180 days"
+        resolution: "Comment or close the issue"
         type: issue
-        resolution: Close or deprioritize
         filters:
-          - label: "P1"
-          - label: "!enhancement"
-          - label: "!bug"
-
-      p1-prs:
-        name: "p1 Pull Requests"
-        type: pull_request
-        resolution: Merge em
-        filters:
-          - label: "P1"
-
-      # P2
-      p2-bugs:
-        name: "p2 Bugs"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P2"
-          - label: "bug"
-
-      p2-enhancements:
-        name: "p2 Features"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P2"
-          - label: "enhancement"
-
-      p2-other:
-        name: "P2 Other"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P2"
-          - label: "!enhancement"
-          - label: "!bug"
-
-      p2-prs:
-        name: "p2 Pull Requests"
-        type: pull_request
-        resolution: Merge em
-        filters:
-          - label: "P2"
-      # P3
-      p3-bugs:
-        name: "p3 Bugs"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P3"
-          - label: "bug"
-
-      p3-enhancements:
-        name: "p3 Features"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P3"
-          - label: "enhancement"
-
-      p3-other:
-        name: "P3 Other"
-        type: issue
-        resolution: Close or deprioritize
-        filters:
-          - label: "P3"
-          - label: "!enhancement"
-          - label: "!bug"
-
-      p3-prs:
-        name: "p3 Pull Requests"
-        type: pull_request
-        resolution: Merge em
-        filters:
-          - label: "P3"
+          - responded: +180d
+          - created: +180d
+          - label: "!kind/feature"
+          - label: "!kind/bug"
+          - label: "!kind/support"
 
       ## Similar
       similar-prs:
@@ -485,13 +571,21 @@ data:
         filters:
           - tag: similar
 
+
       # for statistics generation
       open-issues:
         name: "Open Issues"
         type: issue
-        state: open
 
       open-prs:
         name: "Open PRs"
         type: pull_request
-        state: open
+
+      closed-milestone-issues:
+        name: "Recently closed milestone issues"
+        type: issue
+        filters:
+          - state: closed
+          - closed: -90d
+          - milestone: ".*"
+          - label: "!triage/duplicate"

--- a/configmap-tinkerbell.yaml
+++ b/configmap-tinkerbell.yaml
@@ -31,8 +31,8 @@ data:
         - https://github.com/tinkerbell/tinkerbell.org
 
     collections:
-      - id: weekly
-        name: Semi-weekly
+      - id: daily
+        name: Daily
         dedup: true
         description: >
           Reviewed during the week.
@@ -58,7 +58,7 @@ data:
           - issue-updated-needs-info
           - issue-updated-has-question
 
-      - id: biweekly
+      - id: weekly
         name: Bi-weekly
         dedup: true
         description: >


### PR DESCRIPTION
A fairly large refactoring of the rules, primarily around the new `kind/` and `priority/` labels that have been deployed within the Tinkerbell repos. 